### PR TITLE
lastcol is zero-indexed, like lastrow, in xls from some 3rd party tools

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -1708,7 +1708,7 @@ xlsCell	*xls_cell(xlsWorkSheet* pWS, WORD cellRow, WORD cellCol)
 
     if(cellRow > pWS->rows.lastrow) return NULL;
     row = &pWS->rows.row[cellRow];
-    if(cellCol >= row->lcell) return NULL;
+    if(cellCol > row->lcell) return NULL;
 
     return &row->cells.cell[cellCol];
 }


### PR DESCRIPTION
We have changed this inequality in readxl, because we have found that some 3rd party tools produce xls where lastcol is zero-indexed in the same way as lastrow.

Here is a test sheet in readxl that exhibits this quality:

https://github.com/tidyverse/readxl/blob/eeeebf8171540a7cd14b373d20b08efbac7e3cd2/tests/testthat/sheets/mtcars.xls

Here is how I made this file:

https://github.com/tidyverse/readxl/blob/eeeebf8171540a7cd14b373d20b08efbac7e3cd2/tests/testthat/test-compatibility.R#L10-L18

The fix in this PR, in readxl, resolved these issues: https://github.com/tidyverse/readxl/issues/180, https://github.com/tidyverse/readxl/issues/152, https://github.com/tidyverse/readxl/issues/99