### PR TITLE
Shared string table indexing and LABEL records

### DIFF
--- a/include/libxls/xlstool.h
+++ b/include/libxls/xlstool.h
@@ -47,6 +47,6 @@ extern void xls_showCell(struct st_cell_data* cell);
 extern void xls_showFont(struct st_font_data* font);
 extern void xls_showXF(XF8* xf);
 extern void xls_showFormat(struct st_format_data* format);
-extern char* xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, WORD *label);
+extern char* xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, BYTE *label);
 extern char* xls_getCSS(xlsWorkBook* pWB);
 extern void xls_showBOF(BOF* bof);

--- a/src/endian.c
+++ b/src/endian.c
@@ -103,8 +103,10 @@ void xlsConvertBiff(BIFF *b)
     b->type = xlsShortVal(b->type);
     b->id_make = xlsShortVal(b->id_make);
     b->year = xlsShortVal(b->year);
-    b->flags = xlsIntVal(b->flags);
-    b->min_ver = xlsIntVal(b->min_ver);
+    if (b->ver == 0x600) {
+      b->flags = xlsIntVal(b->flags);
+      b->min_ver = xlsIntVal(b->min_ver);
+    }
 }
 
 void xlsConvertWindow(WIND1 *w)

--- a/src/xls.c
+++ b/src/xls.c
@@ -553,7 +553,7 @@ struct st_cell_data *xls_addCell(xlsWorkSheet* pWS,BOF* bof,BYTE* buf)
     case XLS_RECORD_LABEL:
         if (bof->size < sizeof(LABEL))
             return NULL;
-		cell->str=xls_getfcell(pWS->workbook,cell,(WORD_UA *)&((LABEL*)buf)->value);
+		cell->str=xls_getfcell(pWS->workbook,cell,(BYTE *)&((LABEL*)buf)->value);
         if (cell->str) {
             sscanf((char *)cell->str, "%d", &cell->l);
             sscanf((char *)cell->str, "%lf", &cell->d);

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -559,7 +559,7 @@ void xls_showXF(XF8* xf)
     printf("GroundColor: 0x%x\n",xf->groundcolor);
 }
 
-char *xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, WORD *label)
+char *xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, BYTE *label)
 {
     struct st_xf_data *xf = NULL;
 	WORD	len = 0;
@@ -585,7 +585,7 @@ char *xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, WORD *label)
         break;
     case XLS_RECORD_LABEL:
 		len = xlsShortVal(*label);
-        label++;
+        label += 2;
 		if(pWB->is5ver) {
             ret = malloc(len+1);
             memcpy(ret, label, len);


### PR DESCRIPTION
Patch from readxl: https://github.com/tidyverse/readxl/pull/312

I did this over a year ago and am still trying to get back on top of all the details. Also not sure how this integrates with the current form of libxls, although I believe this issue to still be relevant. Consider this PR a conversation starter.

The most important excerpt from the above PR:

> The fix re: using longer integers to index into the shared string table (https://github.com/tidyverse/readxl/pull/293) actually breaks the string extraction for LABEL records. All of this is libxls problems/bugs btw. The problem is that `label` needs to be a pointer to `uint32_t` for parsing modern BIFF8 sheets / LABELSST records and a pointer to `uint16_t` for sheets like the one in https://github.com/tidyverse/readxl/issues/309. This only matters for advancing label past the string length, so it points at the beginning of the string.

I previously reported the problem of indexing into the SST to libxls (https://sourceforge.net/p/libxls/bugs/28/) and my first solution was adopted (it is part of https://sourceforge.net/p/libxls/code/175/). Unfortunately, it wasn't the ideal solution. Specifically, it caused problems for parsing LABEL records in BIFF5 sheets. We subsequently settled on the solution in this PR in readxl and my original fix has also since been reverted in libxls. I think that means libxls still has a problem, though.

This readxl PR contains the most detail on the diagnosis: https://github.com/tidyverse/readxl/pull/293

Test sheets and tests that I believe to be relevant:

Test:
https://github.com/tidyverse/readxl/blob/eeeebf8171540a7cd14b373d20b08efbac7e3cd2/tests/testthat/test-compatibility.R#L33-L45

Sheet:
https://github.com/tidyverse/readxl/blob/master/tests/testthat/sheets/biff5-label-records.xls

Test:
https://github.com/tidyverse/readxl/blob/eeeebf8171540a7cd14b373d20b08efbac7e3cd2/tests/testthat/test-shared-string-table.R#L3-L8

Sheet:
https://github.com/tidyverse/readxl/blob/eeeebf8171540a7cd14b373d20b08efbac7e3cd2/tests/testthat/sheets/more-than-256-unique-strings-xls.xls





