### PR TITLE
Accomodate Solaris

### DIFF
--- a/formulas/xlsformula.h
+++ b/formulas/xlsformula.h
@@ -33,7 +33,7 @@
 #ifndef libXlsTester_xlsformula_h
 #define libXlsTester_xlsformula_h
 
-#ifdef AIX
+#if defined(_AIX) || defined(__sun)
 #pragma pack(1)
 #else
 #pragma pack(push, 1)

--- a/include/libxls/ole.h
+++ b/include/libxls/ole.h
@@ -37,7 +37,7 @@
 
 #include "libxls/xlstypes.h"
 
-#ifdef AIX
+#if defined(_AIX) || defined(__sun)
 #pragma pack(1)
 #else
 #pragma pack(push, 1)
@@ -140,7 +140,7 @@ typedef struct OLE2Stream
 }
 OLE2Stream;
 
-#ifdef AIX
+#if defined(_AIX) || defined(__sun)
 #pragma pack(1)
 #else
 #pragma pack(push, 1)

--- a/include/libxls/xlsstruct.h
+++ b/include/libxls/xlsstruct.h
@@ -80,7 +80,7 @@
 
 #define BLANK_CELL  XLS_RECORD_BLANK  // compat
 
-#ifdef AIX
+#if defined(_AIX) || defined(__sun)
 #pragma pack(1)
 #else
 #pragma pack(push, 1)

--- a/src/xls.c
+++ b/src/xls.c
@@ -74,7 +74,7 @@ extern xls_error_t xls_formatColumn(xlsWorkSheet* pWS);
 extern xls_error_t xls_parseWorkSheet(xlsWorkSheet* pWS);
 extern void xls_dumpSummary(char *buf, int isSummary, xlsSummaryInfo *pSI);
 
-#ifdef AIX
+#if defined(_AIX) || defined(__sun)
 #pragma pack(1)
 #else
 #pragma pack(push, 1)

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -175,7 +175,7 @@ char* unicode_decode(const char *s, size_t len, size_t *newlen, const char* to_e
 {
 #ifdef HAVE_ICONV
 	// Do iconv conversion
-#ifdef AIX
+#if defined(_AIX) || defined(__sun)
     const char *from_enc = "UTF-16le";
 #else
     const char *from_enc = "UTF-16LE";


### PR DESCRIPTION
readxl needs this and this is one of my remaining manual patches. If you can tolerate it here, that would be great. We've had it for years FWIW.

Full disclosure: we do not embed `formulas/xlsformula.h` but I applied the same substitution in it for consistency.